### PR TITLE
docs: rewrite README and add .github/settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,104 @@
+---
+# Repository settings managed by probot/settings
+# https://github.com/repository-settings/app
+
+repository:
+  name: ukrainian-voice-transcriber
+  description: >-
+    Single-binary Ukrainian media-to-text transcription powered by
+    Google Gemini via Vertex AI
+  homepage: https://github.com/idvoretskyi/ukrainian-voice-transcriber
+  topics:
+    - go
+    - golang
+    - transcription
+    - ukrainian
+    - gemini
+    - vertex-ai
+    - speech-to-text
+    - cli
+
+  private: false
+  has_issues: true
+  has_projects: false
+  has_wiki: false
+  has_downloads: true
+
+  default_branch: main
+  delete_branch_on_merge: true
+
+  allow_squash_merge: true
+  allow_merge_commit: true
+  allow_rebase_merge: true
+  allow_auto_merge: false
+
+labels:
+  # --- Standard issue triage ---
+  - name: bug
+    color: '#d73a4a'
+    description: Something isn't working
+
+  - name: enhancement
+    color: '#a2eeef'
+    description: New feature or request
+
+  - name: documentation
+    color: '#0075ca'
+    description: Improvements or additions to documentation
+
+  - name: question
+    color: '#d876e3'
+    description: Further information is requested
+
+  - name: duplicate
+    color: '#cfd3d7'
+    description: This issue or pull request already exists
+
+  - name: invalid
+    color: '#e4e669'
+    description: This doesn't seem right
+
+  - name: wontfix
+    color: '#ffffff'
+    description: This will not be worked on
+
+  - name: good first issue
+    color: '#7057ff'
+    description: Good for newcomers
+
+  - name: help wanted
+    color: '#008672'
+    description: Extra attention is needed
+
+  # --- Development ---
+  - name: refactor
+    color: '#fbca04'
+    description: Code refactoring, no functional change
+
+  - name: security
+    color: '#ee0701'
+    description: Security related changes or fixes
+
+  # --- Dependabot: all ecosystems ---
+  - name: dependencies
+    color: '#0366d6'
+    description: Pull requests that update a dependency file
+
+  # --- Dependabot: gomod ecosystem ---
+  - name: golang
+    color: '#00ADD8'
+    description: Go language dependency updates
+
+  # --- Dependabot: github-actions ecosystem ---
+  - name: ci/cd
+    color: '#6f42c1'
+    description: CI/CD pipeline changes
+
+  - name: github-actions
+    color: '#000000'
+    description: Pull requests that update GitHub Actions code
+
+  # --- Dependabot: docker ecosystem ---
+  - name: component/docker
+    color: '#0db7ed'
+    description: Docker related changes

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Run Trivy vulnerability scanner
       if: matrix.tool == 'trivy'
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'

--- a/README.md
+++ b/README.md
@@ -2,166 +2,118 @@
 
 Single-binary Ukrainian media-to-text transcription powered by Google Gemini via Vertex AI.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/idvoretskyi/ukrainian-voice-transcriber/actions/workflows/ci.yml/badge.svg)](https://github.com/idvoretskyi/ukrainian-voice-transcriber/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/idvoretskyi/ukrainian-voice-transcriber/actions/workflows/codeql.yml/badge.svg)](https://github.com/idvoretskyi/ukrainian-voice-transcriber/actions/workflows/codeql.yml)
+[![Security](https://github.com/idvoretskyi/ukrainian-voice-transcriber/actions/workflows/security.yml/badge.svg)](https://github.com/idvoretskyi/ukrainian-voice-transcriber/actions/workflows/security.yml)
+[![Go version](https://img.shields.io/badge/go-1.26-00ADD8?logo=go)](https://go.dev/dl/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ## Features
 
 - Ukrainian language optimized (`uk-UA`)
-- Accepts **both video and audio files** as input
-- **No Google Cloud Storage required** — audio is sent inline to Gemini
-- FFmpeg used only for video-to-audio extraction (skipped for audio files)
-- Cost-efficient default model: `gemini-3.1-flash-lite-preview` (~$0.03/hr of audio)
-- Handles files up to ~8.4 hours in a single request (no chunking needed)
-- Single binary — no extra runtime dependencies
-- All Gemini models selectable via `--model` flag
-
-## Supported Input Formats
-
-| Type | Extensions |
-|------|-----------|
-| **Audio** (sent directly to Gemini) | `.wav`, `.mp3`, `.flac`, `.ogg`, `.m4a`, `.aac`, `.webm`, `.pcm` |
-| **Video** (audio extracted via FFmpeg first) | `.mp4`, `.mkv`, `.mov`, `.avi`, `.wmv`, `.flv`, `.ts`, `.mpeg`, `.3gp` |
+- Accepts **audio and video files** as input
+- **No Cloud Storage required** — audio bytes sent inline to Gemini
+- FFmpeg used only for video-to-audio extraction; audio files go straight to Gemini
+- Handles files up to ~8.4 hours in a single request (no chunking)
+- Selectable Gemini model via `--model` flag (default: `gemini-3.1-flash-lite-preview`)
+- Single static binary — no extra runtime dependencies beyond FFmpeg for video
 
 ## Quick Start
 
 ### Prerequisites
 
 ```bash
-# Install FFmpeg (only needed for video files)
-brew install ffmpeg        # macOS
-sudo apt install ffmpeg    # Ubuntu/Debian
-
-# Install Go 1.26+
+# Go 1.26+
 brew install go            # macOS
+# sudo apt install golang-go  # Ubuntu/Debian
+
+# FFmpeg (only required for video files)
+brew install ffmpeg        # macOS
+# sudo apt install ffmpeg    # Ubuntu/Debian
 ```
 
-### Installation
+### Install
 
 ```bash
 go install github.com/idvoretskyi/ukrainian-voice-transcriber/cmd/transcriber@latest
 ```
 
-> **Note**: Ensure `$(go env GOPATH)/bin` is in your `$PATH`:
-> ```bash
-> export PATH="$(go env GOPATH)/bin:$PATH"
-> ```
-
-### Authentication & Setup
+Ensure `$(go env GOPATH)/bin` is on your `$PATH`:
 
 ```bash
-# Authenticate with Google Cloud
+export PATH="$(go env GOPATH)/bin:$PATH"
+```
+
+### Google Cloud setup
+
+```bash
+# Authenticate
 gcloud auth login
 gcloud auth application-default login
-gcloud config set project YOUR_PROJECT_ID
 
-# Enable the Vertex AI API
+# Set project and enable Vertex AI
+gcloud config set project YOUR_PROJECT_ID
 gcloud services enable aiplatform.googleapis.com
 ```
+
+The project is also read from the `GOOGLE_CLOUD_PROJECT` environment variable if set.
 
 ### Usage
 
 ```bash
-# Transcribe a video file (FFmpeg extracts audio automatically)
-transcriber transcribe input/video.mp4
+# Transcribe a video file (audio extracted via FFmpeg automatically)
+transcriber transcribe input/meeting.mp4
 
-# Transcribe an audio file directly (no FFmpeg needed)
-transcriber transcribe input/recording.wav
+# Transcribe an audio file directly
 transcriber transcribe input/interview.mp3
 
-# Save to a specific output file
-transcriber transcribe input/video.mp4 -o output.txt
+# Specify output file
+transcriber transcribe input/meeting.mp4 -o transcript.txt
 
-# Use a different Gemini model
-transcriber transcribe input/video.mp4 --model gemini-2.5-flash
+# Use a different model or region
+transcriber transcribe input/meeting.mp4 --model gemini-2.5-flash --location europe-west4
 
-# Use a different Vertex AI region
-transcriber transcribe input/video.mp4 --location europe-west4
-
-# Verbose mode (show detailed progress)
-transcriber transcribe input/video.mp4 --verbose
-
-# Quiet mode (only output the transcript path)
-transcriber transcribe input/video.mp4 --quiet
+# Show version
+transcriber version
 ```
 
 ## CLI Reference
 
 ```
+Usage:
+  transcriber transcribe [media-file] [flags]
+  transcriber version
+
 Flags:
-  --model string      Gemini model to use (default: gemini-3.1-flash-lite-preview)
-  --location string   Vertex AI region (default: us-central1)
-  -o, --output string Output file path (default: output/<name>/<name>.txt)
+  --model string      Gemini model to use
+                      (default: gemini-3.1-flash-lite-preview)
+  --location string   Vertex AI region
+                      (default: us-central1)
+  -o, --output string Output file path
+                      (default: output/<name>/<name>.txt)
   -v, --verbose       Enable verbose output
   -q, --quiet         Suppress all output except results
 ```
 
-## Model Selection Guide
+## Supported Formats
 
-| Model | ~Cost/hr audio | Quality | Status | Best for |
-|-------|---------------|---------|--------|----------|
-| `gemini-3.1-flash-lite-preview` | ~$0.03 | Excellent (ASR-optimized) | Preview | **Default** — best quality/cost |
-| `gemini-2.5-flash-lite` | ~$0.01 | Good | GA | Maximum cost savings |
-| `gemini-2.5-flash` | ~$0.04 | Very good | GA | Production stability |
+| Type | Extensions |
+|------|------------|
+| **Audio** — sent directly to Gemini | `.wav` `.mp3` `.flac` `.ogg` `.m4a` `.aac` `.webm` `.pcm` |
+| **Video** — audio extracted via FFmpeg | `.mp4` `.mkv` `.mov` `.avi` `.wmv` `.flv` `.ts` `.mpeg` `.3gp` |
 
-> Pricing estimates based on 25 tokens/second of audio at published Gemini API rates.
-
-## Output Directory Structure
-
-```
-ukrainian-voice-transcriber/
-├── input/               # Place your media files here
-│   └── video.mp4
-│   └── recording.wav
-├── output/              # Transcripts are automatically saved here
-│   └── video/
-│       └── video.txt
-└── ukrainian-voice-transcriber  # The binary
-```
-
-## Examples
-
-```bash
-# Transcribe a long meeting recording (3-4 hours — handled in a single API call)
-transcriber transcribe input/board-meeting.mp4
-
-# Transcribe an interview audio file
-transcriber transcribe input/interview.m4a
-
-# Batch process all video files
-for f in input/*.mp4; do
-    transcriber transcribe "$f"
-done
-
-# Batch process mixed audio and video
-for f in input/*; do
-    transcriber transcribe "$f"
-done
-```
-
-## Troubleshooting
-
-**FFmpeg not found**: Only needed for video files. `brew install ffmpeg` or `sudo apt install ffmpeg`
-
-**Authentication error**: Run `gcloud auth application-default login`
-
-**Project not set**: Run `gcloud config set project YOUR_PROJECT_ID` or `export GOOGLE_CLOUD_PROJECT=your-project-id`
-
-**API not enabled**: Run `gcloud services enable aiplatform.googleapis.com`
-
-**Permission denied on binary**: Make sure `$GOPATH/bin` is in your `$PATH`
+Extension matching is case-insensitive. Maximum file size: 10 GB.
 
 ## Building from Source
 
 ```bash
 git clone https://github.com/idvoretskyi/ukrainian-voice-transcriber.git
 cd ukrainian-voice-transcriber
-make build
+make build   # produces ./ukrainian-voice-transcriber
+make test    # run tests with race detector
+make lint    # run golangci-lint
 ```
 
 ## License
 
-MIT License — see LICENSE file for details.
-
----
-
-Made for Ukrainian content creators
+MIT — see [LICENSE](LICENSE) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Supported Versions
+
+No stable releases have been cut yet. Security fixes are applied to the
+`main` branch and will be included in the first and all subsequent releases.
+
+| Version | Supported |
+|---------|-----------|
+| `main` (latest) | Yes |
+| older commits | No — please update to `main` |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Use one of the following channels:
+
+### GitHub Private Vulnerability Reporting (preferred)
+
+Open a [private security advisory](https://github.com/idvoretskyi/ukrainian-voice-transcriber/security/advisories/new)
+directly in this repository. GitHub keeps the report private until a fix is
+published.
+
+### Email
+
+Send details to **ihor@dvoretskyi.com** with the subject line:
+`[SECURITY] ukrainian-voice-transcriber: <brief description>`
+
+Please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Any suggested fix or mitigation, if you have one
+
+## Response Timeline
+
+| Milestone | Target |
+|-----------|--------|
+| Initial acknowledgement | Within **48 hours** |
+| Severity assessment | Within **5 business days** |
+| Fix for Critical / High | Within **7 days** of confirmation |
+| Fix for Medium / Low | Within **30 days** of confirmation |
+| Public disclosure | After fix is released, coordinated with reporter |
+
+## Automated Security Scanning
+
+The following tools run automatically on every push and pull request:
+
+| Tool | What it checks |
+|------|---------------|
+| [Trivy](https://github.com/aquasecurity/trivy) v0.35 | Dependency vulnerabilities (CRITICAL, HIGH, MEDIUM) |
+| [gosec](https://github.com/securego/gosec) | Go source code security issues |
+| [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | Known vulnerabilities in Go module dependencies |
+| [CodeQL](https://codeql.github.com) | Static analysis for security and quality issues |
+| [Dependency Review](https://github.com/actions/dependency-review-action) | New vulnerable dependencies introduced in PRs |
+
+SARIF results from Trivy, gosec, and CodeQL are uploaded to
+[GitHub Code Scanning](https://github.com/idvoretskyi/ukrainian-voice-transcriber/security/code-scanning).
+
+## Scope
+
+The following are **in scope** for security reports:
+
+- Vulnerabilities in the transcriber binary itself
+- Unsafe handling of user-supplied file paths or filenames
+- Credential or token exposure in logs or output
+- Dependency vulnerabilities with a realistic attack vector in this tool's use case
+
+The following are **out of scope**:
+
+- Vulnerabilities in Google Cloud / Vertex AI infrastructure
+- Issues requiring physical access to the machine running the binary
+- Social engineering attacks


### PR DESCRIPTION
## Summary

- **README rewrite**: lean, up-to-date, with proper badges (CI, CodeQL, Security, Go version, License). Removes stale references to Speech-to-Text API and Cloud Storage. Accurate CLI reference, supported formats table, and building-from-source section. No pricing table or output directory tree.

- **`.github/settings.yml` (new)**: declarative repo configuration for [probot/settings](https://github.com/repository-settings/app):
  - Updates repo description from stale "Google Cloud Speech-to-Text API" to "Google Gemini via Vertex AI"
  - Sets topics: `go`, `golang`, `transcription`, `ukrainian`, `gemini`, `vertex-ai`, `speech-to-text`, `cli`
  - Enables `delete_branch_on_merge`
  - Declares all labels required by dependabot and CI — including the missing `golang`, `ci/cd`, `github-actions`, and `component/docker` labels that dependabot was silently dropping (the existing `github_actions` label used an underscore instead of the hyphen dependabot expects)

## Labels added

| Label | Used by |
|-------|---------|
| `golang` | dependabot gomod PRs |
| `ci/cd` | dependabot github-actions PRs |
| `github-actions` | dependabot github-actions PRs (fixes `github_actions` mismatch) |
| `component/docker` | dependabot docker PRs |
| `security` | security-related issues/PRs |
| `refactor` | refactoring PRs |